### PR TITLE
We can (now?) use value_to_string and avoid problems with custom fields.

### DIFF
--- a/cache_toolbox/core.py
+++ b/cache_toolbox/core.py
@@ -67,13 +67,8 @@ def get_instance(model, instance_or_pk, timeout=None, using=None):
         if field.primary_key:
             continue
 
-        if field.get_internal_type() == 'FileField':
-            # Avoid problems with serializing FileFields
-            # by only serializing the file name
-            file = getattr(instance, field.attname)
-            data[field.attname] = file.name
-        else:
-            data[field.attname] = getattr(instance, field.attname)
+        # Serialise the instance using the Field's own serialisation routines.
+        data[field.attname] = field.value_to_string(instance)
 
     if timeout is None:
         timeout = app_settings.CACHE_TOOLBOX_DEFAULT_TIMEOUT


### PR DESCRIPTION
Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>